### PR TITLE
Added identifier, required since rc release no. 7

### DIFF
--- a/src/services/resend.ts
+++ b/src/services/resend.ts
@@ -19,6 +19,7 @@ export interface ResendNotificationServiceOptions {
 }
 
 export class ResendNotificationService extends AbstractNotificationProviderService {
+  static identifier = "resend";
   protected config_: ResendServiceConfig;
   protected logger_: Logger;
   protected resend: Resend;


### PR DESCRIPTION
Since rc relase #7 https://github.com/medusajs/medusa/releases/tag/v2.0.0-rc.7

Modules are required to have a static identifier

On stable 2.0 alpha, I am getting error:

> Error: Module provider C:\Users\username\Documents\project-name\backend\node_modules\@typed-dev\medusa-notification-resend\dist\index.js does not have a static "identifier" property on its service class.

Adding `static identifier = "resend";` fixed the error.