### PR TITLE
Added static identifier required for Medusa v2 stable 🚀🔧

### DIFF
--- a/src/services/resend.ts
+++ b/src/services/resend.ts
@@ -19,6 +19,7 @@ export interface ResendNotificationServiceOptions {
 }
 
 export class ResendNotificationService extends AbstractNotificationProviderService {
+  static identifier = "RESEND_NOTIFICATION_SERVICE" //added static identifier required in medusa v2 stable
   protected config_: ResendServiceConfig;
   protected logger_: Logger;
   protected resend: Resend;


### PR DESCRIPTION
Added ```ts static identifier = "RESEND_NOTIFICATION_SERVICE" ```
which leads to medusa v2.0 stable breaking if not present